### PR TITLE
fix(booking): Update permission for booking refund endpoint

### DIFF
--- a/src/modules/booking/booking.controller.ts
+++ b/src/modules/booking/booking.controller.ts
@@ -402,7 +402,7 @@ export class BookingController {
     propertyIdSource: 'param',
     propertyIdParam: 'propertyId',
   })
-  @RequirePermission('booking.refund')
+  @RequirePermission('booking.cancel')
   @ApiOperation({ summary: 'Admin/Staff hoàn tiền booking với ảnh minh chứng' })
   @ApiParam({ name: 'propertyId', description: 'ID của property' })
   @ApiParam({ name: 'id', description: 'ID của booking' })


### PR DESCRIPTION
- Changed permission requirement from 'booking.refund' to 'booking.cancel' for the booking refund operation in the BookingController.